### PR TITLE
Add automatic formatting and linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .idea
+portfolio/node_modules

--- a/portfolio/.eslintrc
+++ b/portfolio/.eslintrc
@@ -1,0 +1,15 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "extends": ["eslint:recommended", "google"],
+  "rules": {
+    "require-jsdoc": "off",
+    "valid-jsdoc": "off",
+    "object-curly-spacing": "off"
+  }
+}

--- a/portfolio/.prettierrc
+++ b/portfolio/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/portfolio/Makefile
+++ b/portfolio/Makefile
@@ -1,0 +1,11 @@
+install:
+	npm install --no-package-lock --no-audit
+	echo "#!/bin/sh\n\tcd portfolio && make format && make lint" > ../.git/hooks/pre-push
+	chmod +x ../.git/hooks/pre-push
+
+format: install
+	npx prettier --write src/main/webapp/**/*.{html,css,js}
+	mvn com.coveo:fmt-maven-plugin:format -Dverbose=true
+
+lint: install
+	npx eslint src/main/webapp/**/*.js

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "eslint-config-google": "^0.14.0",
+    "eslint": "^7.2.0",
+    "prettier": "^2.0.5"
+  }
+}

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -39,6 +39,22 @@
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.9</version>
+        <configuration>
+          <verbose>true</verbose>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>
+


### PR DESCRIPTION
**summary**
This PR adds in automatic code formatting and linting. It also adds make commands as well as a git hook so that these commands are automatically run when performing a `git push`. If you'd like to skip the hook, you can use `git push --no-verify`.

I recommend installing a prettier plugin for whichever IDE/code editor you are using.

new commands:
- `make install`: install the dependencies needed for `format` and `lint`.
- `make lint`: run eslint on all of your javascript files.
- `make format`: run [prettier](https://github.com/prettier/prettier) on the html/css/js files, as well as [google-java-format](https://github.com/google/google-java-format) on the java files.


**next steps**
- @kwell755 to run `make format` and `make lint` until master branch is passing :). May also need to install node/npm if not already available.